### PR TITLE
Upgrade pedestal-toolbox to 0.7.0 CORS regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ HTTP API gateway for vote-by-mail services.
 * ALLOWED_ORIGINS
     * This env var controls the cross-origin resource sharing (CORS) settings.
     * It should be set to one of the following:
-        * `:all` to allow requests from any origin
+        * `[".*"]` to allow requests from any origin
         * an EDN seq of allowed origin strings
         * an EDN map containing the following keys and values
             * :allowed-origins - sequence of strings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ app:
     - rabbitmq
     - wildfly
   environment:
-    ALLOWED_ORIGINS: :all
+    ALLOWED_ORIGINS: '[".*"]'
 wildfly:
   image: quay.io/democracyworks/wildfly:9.0.2.Final-debug
   links:

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
 
                  [io.pedestal/pedestal.service "0.4.1"]
                  [io.pedestal/pedestal.service-tools "0.4.1"]
-                 [democracyworks/pedestal-toolbox "0.6.2"]
+                 [democracyworks/pedestal-toolbox "0.7.0"]
                  [org.immutant/web "2.1.2"]
                  [io.pedestal/pedestal.immutant "0.4.1"]
                  [org.immutant/core "2.1.2"]

--- a/src/vote_by_mail_http_api/service.clj
+++ b/src/vote_by_mail_http_api/service.clj
@@ -5,6 +5,7 @@
             [io.pedestal.interceptor :refer [interceptor]]
             [ring.util.response :as ring-resp]
             [turbovote.resource-config :refer [config]]
+            [pedestal-toolbox.cors :as cors]
             [pedestal-toolbox.params :refer :all]
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
@@ -36,9 +37,9 @@
    ::bootstrap/router :linear-search
    ::bootstrap/routes routes
    ::bootstrap/resource-path "/public"
-   ::bootstrap/allowed-origins (if (= :all (config [:server :allowed-origins]))
-                                 (constantly true)
-                                 (config [:server :allowed-origins]))
+   ::bootstrap/allowed-origins (cors/domain-matcher-fn
+                                (map re-pattern
+                                     (config [:server :allowed-origins])))
    ::bootstrap/host (config [:server :hostname])
    ::bootstrap/type :immutant
    ::bootstrap/port (config [:server :port])})


### PR DESCRIPTION
This is a routine upgrade and will be merged when the build passes.

We're upgrading pedestal-toolbox to use regexes instead of strings.